### PR TITLE
Fix Login response trả về client

### DIFF
--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -31,7 +31,7 @@ class AuthService
 
         // Trả về token và thông tin người dùng
         return [
-            'user' => $user,
+            'id' => $user->id,
             'token' => $user->createToken('API Token')->plainTextToken
         ];
     }


### PR DESCRIPTION
Trả về cho client user_id và token để người dùng truy cập vào các tác vụ khác, còn lại không trả thêm thông tin gì ngoài những trường trên